### PR TITLE
Use specified python version during setup

### DIFF
--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -7,9 +7,14 @@ parameters:
     type: string
     default: "."
 
+  python-version:
+    description: Python version in use. Defaults to 3.7
+    type: string
+    default: "3.7"
+
 steps:
   - restore_cache:
-      key: v0-{{ .Branch }}-{{ checksum "<< parameters.project-location >>/Pipfile.lock" }}
+      key: v0-{{ .Branch }}-{{ checksum "<< parameters.python-version >>:<< parameters.project-location >>/Pipfile.lock" }}
   - run:
       name: Install dependencies
       command: |
@@ -17,8 +22,8 @@ steps:
         sudo pip install pipenv
         pipenv install --deploy --dev
   - save_cache:
-      key: v0-{{ .Branch }}-{{ checksum "<< parameters.project-location >>/Pipfile.lock" }}
+      key: v0-{{ .Branch }}-{{ checksum "<< parameters.python-version >>:<< parameters.project-location >>/Pipfile.lock" }}
       paths:
         - "<< parameters.project-location >>/.venv"
         - "/usr/local/bin"
-        - "/usr/local/lib/python3.7/site-packages"
+        - "/usr/local/lib/python<< parameters.python-version >>/site-packages"

--- a/src/jobs/check.yml
+++ b/src/jobs/check.yml
@@ -40,9 +40,10 @@ docker:
 steps:
   - checkout
   - run: sudo chown -R circleci:circleci /usr/local/bin
-  - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
+  - run: sudo chown -R circleci:circleci /usr/local/lib/python<< parameters.python-version >>/site-packages
   - setup:
       project-location: << parameters.project-location >>
+      python-version: << parameters.python-version >>
   - lint:
       project-location: << parameters.project-location >>
       black: << parameters.black >>


### PR DESCRIPTION
- Add Python version to Pipfile checksum so that the cache is cleared when the Python version changes.
- Make paths use the specified version, not hardcoded to 3.7.